### PR TITLE
Use existing alt text and caption in rich content

### DIFF
--- a/src/Form/RichEditor/MediaManagerRichContentPlugin.php
+++ b/src/Form/RichEditor/MediaManagerRichContentPlugin.php
@@ -158,8 +158,8 @@ class MediaManagerRichContentPlugin implements HasFileAttachmentProvider, HasToo
                                         'type' => 'image',
                                         'attrs' => [
                                             'src' => $url,
-                                            'alt' => $file->name,
-                                            'title' => $file->name,
+                                            'alt' => $file->alt_text ?? $file->name,
+                                            'title' => $file->caption ?? $file->name,
                                             'id' => $file->id,
                                         ],
                                     ],

--- a/src/Livewire/MediaBrowser.php
+++ b/src/Livewire/MediaBrowser.php
@@ -1108,6 +1108,10 @@ class MediaBrowser extends Component implements HasActions, HasForms
                 ->state($file->caption)
                 ->visible((bool) $file->caption),
 
+            TextEntry::make('alt_text')
+                ->state($file->alt_text)
+                ->visible((bool) $file->alt_text),
+
             TextEntry::make('sel_path')
                 ->label('Public URL')
                 ->state($file->getUrl())


### PR DESCRIPTION
## Change
- Use the existing alt_text and caption (for title) if available when inserting an image into rich content.
  - when alt_text or caption are not available -> defaults to file name (current behavior) 
- Add a TextEntry with the alt text to the Media Browser